### PR TITLE
Display usage if project name is missing

### DIFF
--- a/sourceforge-file-downloader.sh
+++ b/sourceforge-file-downloader.sh
@@ -1,5 +1,16 @@
 #!/bin/sh
 
+display_usage() {
+  echo "Downloads all of a SourceForge project's files."
+  echo "\nUsage: ./sourceforge-file-download.sh [project name] \n"
+}
+
+if [ $# -eq 0 ]
+then
+  display_usage
+  exit 1
+fi
+
 project=$1
 echo "Downloading $project's files"
 


### PR DESCRIPTION
Guide the user if they don't provide a project name.